### PR TITLE
feat: Add configurable port via environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 ## Installation
 ### Using docker
 ```bash
-docker run -d --name streamdock --network host --restart unless-stopped ghcr.io/limmer55/streamdock:latest
+docker run -d --name streamdock --network host -e PORT=6050 --restart unless-stopped ghcr.io/limmer55/streamdock:latest
 
 ```
 ### Docker Compose
@@ -32,6 +32,7 @@ services:
     network_mode: host
     environment:
       M3U_URL: "https://iptv-org.github.io/iptv/index.m3u" # optional, can be set in settings later
+      PORT: "6050"  # Set your desired port here, default 6050
     restart: unless-stopped
 
 ```

--- a/source/Dockerfile
+++ b/source/Dockerfile
@@ -13,9 +13,10 @@ COPY . .
 
 ENV FLASK_APP run.py
 ENV FLASK_ENV production
+ENV PORT=6050
 
 
-EXPOSE 6050
+EXPOSE ${PORT}
 
 
-CMD ["gunicorn", "--bind", "0.0.0.0:6050", "run:app"]
+CMD gunicorn --bind 0.0.0.0:${PORT} run:app

--- a/source/run.py
+++ b/source/run.py
@@ -1,5 +1,6 @@
 from app import create_app
 import logging
+import os
 
 log = logging.getLogger('werkzeug')
 log.setLevel(logging.ERROR)
@@ -7,4 +8,5 @@ log.setLevel(logging.ERROR)
 app = create_app()
 
 if __name__ == "__main__":
-    app.run(host="0.0.0.0", port=6050)
+    port = int(os.environ.get("PORT", 6050))
+    app.run(host="0.0.0.0", port=port)


### PR DESCRIPTION
This PR adds the ability to configure the application's port through an environment variable, making it more flexible for different deployment scenarios.

Changes made:
- Modified Dockerfile to use PORT environment variable (default: 6050)
- Updated run.py to read port from environment variable
- Port can now be configured through docker-compose.yml or docker run command

Example usage:
```yaml
# docker-compose.yml
services:
  streamdock:
    environment:
      PORT: "6050"  # Custom port
```

or 

```bash 
docker run -e PORT=6050 ghcr.io/limmer55/streamdock:latest
```      